### PR TITLE
Remove CallAgent creation from Lobby View

### DIFF
--- a/AzureCalling/External/Calling/CallingContext.swift
+++ b/AzureCalling/External/Calling/CallingContext.swift
@@ -70,7 +70,6 @@ class CallingContext: NSObject {
     }
 
     func joinCall(_ joinConfig: JoinCallConfig, completionHandler: @escaping (Result<Void, Error>) -> Void) {
-        self.callAgent = nil
         self.setupCallAgent(displayName: joinConfig.displayName) { [weak self] _ in
             guard let self = self else {
                 return
@@ -249,17 +248,7 @@ class CallingContext: NSObject {
 
     private func setupCalling(completionHandler: @escaping (Result<Void, Error>) -> Void) {
         callClient = CallClient()
-        setupCallAgent(displayName: "") { [weak self] result in
-            guard let self = self else {
-                return
-            }
-
-            if case .failure(let error) = result {
-                completionHandler(.failure(error))
-                return
-            }
-            self.setupDeviceManager(completionHandler: completionHandler)
-        }
+        self.setupDeviceManager(completionHandler: completionHandler)
     }
 
     private func setupCallAgent(displayName: String, completionHandler: @escaping (Result<Void, Error>) -> Void) {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* The Beta 12 SDK now supports the creation of DeviceManager without first having a CallAgent
* Since a User name could only be set on CallAgent creation, we had to remove and re-create the CallAgent after a user entered their display name
* We can remove the unnecessary CallAgent creation step in the Lobby View

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
- Join a Group Call with one or more remote participants

## What to Check
Verify that the following are valid
* You can turn on and off your video in Lobby View
* You can turn on and off your video in Call View

## Other Information
<!-- Add any other helpful information that may be needed here. -->