### PR TITLE
Upgrade calling SDK to v1.0.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ use_frameworks!
 
 target 'AzureCalling' do
 
-pod 'AzureCommunicationCalling', '1.0.0-beta.12'
+pod 'AzureCommunicationCalling', '1.0.1'
 pod 'MSAL', '1.1.13'
 pod 'SwiftLint', '0.42.0'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,34 +1,34 @@
 PODS:
-  - AzureCommunication (1.0.0-beta.11):
-    - AzureCore (= 1.0.0-beta.11)
-  - AzureCommunicationCalling (1.0.0-beta.12):
-    - AzureCommunication (= 1.0.0-beta.11)
-  - AzureCore (1.0.0-beta.11)
+  - AzureCommunicationCalling (1.0.1):
+    - AzureCommunicationCommon (= 1.0.0)
+  - AzureCommunicationCommon (1.0.0):
+    - AzureCore (= 1.0.0-beta.12)
+  - AzureCore (1.0.0-beta.12)
   - MSAL (1.1.13):
     - MSAL/app-lib (= 1.1.13)
   - MSAL/app-lib (1.1.13)
   - SwiftLint (0.42.0)
 
 DEPENDENCIES:
-  - AzureCommunicationCalling (= 1.0.0-beta.12)
+  - AzureCommunicationCalling (= 1.0.1)
   - MSAL (= 1.1.13)
   - SwiftLint (= 0.42.0)
 
 SPEC REPOS:
   trunk:
-    - AzureCommunication
     - AzureCommunicationCalling
+    - AzureCommunicationCommon
     - AzureCore
     - MSAL
     - SwiftLint
 
 SPEC CHECKSUMS:
-  AzureCommunication: ca2435e97c5c95131baa25a3a42104dfa327cf92
-  AzureCommunicationCalling: b0e6a08d0055e55a1ef7b8c6a51743a081031a6f
-  AzureCore: 3b461458a047c838209b0c8bb06f7fd6a8088102
+  AzureCommunicationCalling: 563d3335e454ab057f50409e1d2d63de784227c0
+  AzureCommunicationCommon: 37d81f556d367c8a8e20581da1d8ffea5401cb86
+  AzureCore: 2e029168d18ade4f2e8cc59a96f6d8b26acad2b2
   MSAL: 291d1cfc8d095a6bfe669e4beda2c5be6774a4ff
   SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
 
-PODFILE CHECKSUM: 1d69bd0adcf3e2346a9ec315bc93b4c9fd0296b2
+PODFILE CHECKSUM: 83e9ec469b102e56667fd25973ce7d13ee3845e7
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
## Purpose
Updating calling SDK to GA version 1.0.1, code tested and verified [`iOS local video stream flashes to video off briefly when joining a call with video`](https://github.com/Azure/Communication/issues/191) bug still persists

## Does this introduce a breaking change?
```
[ ] Yes
[ x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x ] Other... Please describe: sdk version upgrade
```