### PR TITLE
Overlay border view to indicate speaking

### DIFF
--- a/AzureCalling.xcodeproj/project.pbxproj
+++ b/AzureCalling.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		8D743159263373ED000D0BCE /* BottomDrawerCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D743157263373ED000D0BCE /* BottomDrawerCellView.swift */; };
 		8D74315B263373F9000D0BCE /* BottomDrawerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D74315A263373F9000D0BCE /* BottomDrawerItem.swift */; };
 		8D74315D26337420000D0BCE /* AudioDeviceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D74315C26337420000D0BCE /* AudioDeviceType.swift */; };
+		986654FD264352A000395329 /* ActiveSpeakerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 986654FC264352A000395329 /* ActiveSpeakerView.swift */; };
 		987C3DC62624DE6200E296D0 /* ParticipantLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987C3DC52624DE6200E296D0 /* ParticipantLabelView.swift */; };
 /* End PBXBuildFile section */
 
@@ -100,6 +101,7 @@
 		8D743157263373ED000D0BCE /* BottomDrawerCellView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BottomDrawerCellView.swift; sourceTree = "<group>"; };
 		8D74315A263373F9000D0BCE /* BottomDrawerItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BottomDrawerItem.swift; sourceTree = "<group>"; };
 		8D74315C26337420000D0BCE /* AudioDeviceType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioDeviceType.swift; sourceTree = "<group>"; };
+		986654FC264352A000395329 /* ActiveSpeakerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveSpeakerView.swift; sourceTree = "<group>"; };
 		987C3DC52624DE6200E296D0 /* ParticipantLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantLabelView.swift; sourceTree = "<group>"; };
 		F538450C6909F619B02539DC /* Pods_AzureCalling.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AzureCalling.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -176,6 +178,7 @@
 				8D74315A263373F9000D0BCE /* BottomDrawerItem.swift */,
 				8D743157263373ED000D0BCE /* BottomDrawerCellView.swift */,
 				8D743156263373ED000D0BCE /* BottomDrawerCellView.xib */,
+				986654FC264352A000395329 /* ActiveSpeakerView.swift */,
 				1F7CD3F225C1E9E80081D8F1 /* ParticipantView.swift */,
 				1F7CD3F425C1E9E80081D8F1 /* ParticipantView.xib */,
 				21C19BBD25C4DEA600EB0991 /* UIRoundedButton.swift */,
@@ -404,6 +407,7 @@
 				1F7CD40625C1E9E80081D8F1 /* FeedbackViewController.swift in Sources */,
 				1FC8820926165A5D002B1947 /* JoinCallConfig.swift in Sources */,
 				1F7CD3FF25C1E9E80081D8F1 /* CallingContext.swift in Sources */,
+				986654FD264352A000395329 /* ActiveSpeakerView.swift in Sources */,
 				8D743153263373C5000D0BCE /* AudioSessionManager.swift in Sources */,
 				21C19BBE25C4DEA600EB0991 /* UIRoundedButton.swift in Sources */,
 				1F7CD40E25C1E9E80081D8F1 /* JoinIdShareItem.swift in Sources */,

--- a/AzureCalling/Views/ActiveSpeakerView.swift
+++ b/AzureCalling/Views/ActiveSpeakerView.swift
@@ -1,0 +1,21 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+
+@IBDesignable
+class ActiveSpeakerView: UIView {
+    @IBInspectable var borderWidth: CGFloat = 0 {
+        didSet {
+            self.layer.borderWidth = borderWidth
+        }
+    }
+
+    @IBInspectable var borderColor: UIColor = UIColor.clear {
+        didSet {
+            self.layer.borderColor = borderColor.cgColor
+        }
+    }
+}

--- a/AzureCalling/Views/ParticipantView.swift
+++ b/AzureCalling/Views/ParticipantView.swift
@@ -21,6 +21,7 @@ class ParticipantView: UIView {
     @IBOutlet var contentView: UIView!
     @IBOutlet weak var placeholderImage: UIImageView!
     @IBOutlet weak var videoViewContainer: UIView!
+    @IBOutlet weak var activeSpeakerView: ActiveSpeakerView!
     @IBOutlet weak var participantLabelView: ParticipantLabelView!
 
     // MARK: Constructors
@@ -46,8 +47,7 @@ class ParticipantView: UIView {
     }
 
     func updateActiveSpeaker(isSpeaking: Bool) {
-        contentView.layer.borderWidth = isSpeaking ? 3 : 0
-        contentView.layer.borderColor = isSpeaking ? ThemeColor.primary.cgColor : UIColor.clear.cgColor
+        activeSpeakerView.isHidden = !isSpeaking
     }
 
     func updateVideoStream(localVideoStream: LocalVideoStream?) {

--- a/AzureCalling/Views/ParticipantView.xib
+++ b/AzureCalling/Views/ParticipantView.xib
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ParticipantView" customModule="AzureCalling" customModuleProvider="target">
             <connections>
+                <outlet property="activeSpeakerView" destination="zye-vX-A83" id="xvx-xU-LbP"/>
                 <outlet property="contentView" destination="iN0-l3-epB" id="450-CQ-3yZ"/>
                 <outlet property="participantLabelView" destination="4tW-72-meb" id="pYy-VX-THl"/>
                 <outlet property="placeholderImage" destination="wyD-Dr-0Cm" id="yQT-C8-AHL"/>
@@ -33,6 +35,17 @@
                         </imageView>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iQU-ZL-awr" userLabel="Video View Container">
                             <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
+                        </view>
+                        <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zye-vX-A83" customClass="ActiveSpeakerView" customModule="AzureCalling" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                    <real key="value" value="3"/>
+                                </userDefinedRuntimeAttribute>
+                                <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                    <color key="value" name="primaryColor"/>
+                                </userDefinedRuntimeAttribute>
+                            </userDefinedRuntimeAttributes>
                         </view>
                         <stackView opaque="NO" alpha="0.59999999999999998" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="4tW-72-meb" customClass="ParticipantLabelView" customModule="AzureCalling" customModuleProvider="target">
                             <rect key="frame" x="8" y="898" width="114.5" height="20"/>
@@ -95,8 +108,12 @@
                     </subviews>
                     <constraints>
                         <constraint firstItem="4tW-72-meb" firstAttribute="leading" secondItem="9aZ-5g-VOP" secondAttribute="leading" constant="8" id="02v-ij-sHT"/>
+                        <constraint firstItem="zye-vX-A83" firstAttribute="top" secondItem="9aZ-5g-VOP" secondAttribute="top" id="6Ou-4v-dO7"/>
+                        <constraint firstItem="zye-vX-A83" firstAttribute="bottom" secondItem="9aZ-5g-VOP" secondAttribute="bottom" id="EL9-fF-SIQ"/>
                         <constraint firstItem="wyD-Dr-0Cm" firstAttribute="centerX" secondItem="9aZ-5g-VOP" secondAttribute="centerX" id="JOW-q7-9Xa"/>
+                        <constraint firstItem="zye-vX-A83" firstAttribute="leading" secondItem="9aZ-5g-VOP" secondAttribute="leading" id="Ji2-Mb-EHQ"/>
                         <constraint firstItem="iQU-ZL-awr" firstAttribute="top" secondItem="9aZ-5g-VOP" secondAttribute="top" id="NoH-hu-tPy"/>
+                        <constraint firstItem="zye-vX-A83" firstAttribute="trailing" secondItem="9aZ-5g-VOP" secondAttribute="trailing" id="Qrw-qm-lbe"/>
                         <constraint firstAttribute="bottom" secondItem="4tW-72-meb" secondAttribute="bottom" constant="8" id="Ug8-05-Te3"/>
                         <constraint firstAttribute="trailing" secondItem="iQU-ZL-awr" secondAttribute="trailing" id="W3V-cn-qjw"/>
                         <constraint firstAttribute="bottom" secondItem="iQU-ZL-awr" secondAttribute="bottom" id="glg-La-xgf"/>
@@ -123,5 +140,8 @@
     <resources>
         <image name="ic_fluent_mic_off_28_filled" width="28" height="28"/>
         <image name="ic_fluent_person_48_filled" width="48" height="48"/>
+        <namedColor name="primaryColor">
+            <color red="0.0" green="0.47058823529411764" blue="0.83137254901960789" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
     </resources>
 </document>


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fixes bug on border being shown partially if we were to change the border programmatically on the content view
* Video rendering causes the border to be interfered with the content, thus overlay remedies this issue by displaying the border on top of the content

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
* Solid border when speaking indicator is up
* Width of the surrounding border should be consistent and span 3px