### PR TITLE
Dispose the existed render view when participantView render new video stream

### DIFF
--- a/AzureCalling/Views/ParticipantView.swift
+++ b/AzureCalling/Views/ParticipantView.swift
@@ -60,6 +60,7 @@ class ParticipantView: UIView {
         if newVideoSourceId == videoStreamId {
             return
         }
+        cleanUpVideoRendering()
 
         do {
             let newRenderer: VideoStreamRenderer = try VideoStreamRenderer(localVideoStream: localVideoStream!)
@@ -80,6 +81,7 @@ class ParticipantView: UIView {
         if newVideoSourceId == videoStreamId {
             return
         }
+        cleanUpVideoRendering()
 
         do {
             let newRenderer: VideoStreamRenderer = try VideoStreamRenderer(remoteVideoStream: remoteVideoStream!)
@@ -94,7 +96,6 @@ class ParticipantView: UIView {
         guard let view = participantLabelView else {
             return
         }
-
         view.isHidden = !isDisplayNameVisible
     }
 


### PR DESCRIPTION
## Purpose
I think we need to dispose the existed render view when there is a new render view input. Found this potential issue when debugging on @jimchou-dev's screen sharing feature which is not working when switching back to user's camera from sharing. 
Please correct me if I miss something.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Test more than 6 users with camera off and on. See if the camera video streams are correct displayed on the app
* Or manual change `remoteParticipantsDisplayed` to 1, and have more than 3 user with camera off and on, and switch user on screen by speaking on different user. See if there is any user's stream video stream missing 