### PR TITLE
Update participant list to be dynamic

### DIFF
--- a/AzureCalling.xcodeproj/project.pbxproj
+++ b/AzureCalling.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		986654FD264352A000395329 /* ActiveSpeakerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 986654FC264352A000395329 /* ActiveSpeakerView.swift */; };
 		987C3DC62624DE6200E296D0 /* ParticipantLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987C3DC52624DE6200E296D0 /* ParticipantLabelView.swift */; };
 		98AF5CDF263B4447007608CD /* ParticipantListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AF5CDE263B4447007608CD /* ParticipantListDataSource.swift */; };
+		98F49DA72654651B00EE4396 /* BottomDrawerDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F49DA62654651B00EE4396 /* BottomDrawerDataSource.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -107,6 +108,7 @@
 		986654FC264352A000395329 /* ActiveSpeakerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveSpeakerView.swift; sourceTree = "<group>"; };
 		987C3DC52624DE6200E296D0 /* ParticipantLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantLabelView.swift; sourceTree = "<group>"; };
 		98AF5CDE263B4447007608CD /* ParticipantListDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantListDataSource.swift; sourceTree = "<group>"; };
+		98F49DA62654651B00EE4396 /* BottomDrawerDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomDrawerDataSource.swift; sourceTree = "<group>"; };
 		F538450C6909F619B02539DC /* Pods_AzureCalling.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AzureCalling.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -253,6 +255,7 @@
 		989F61952649D72F000C5668 /* DataSource */ = {
 			isa = PBXGroup;
 			children = (
+				98F49DA62654651B00EE4396 /* BottomDrawerDataSource.swift */,
 				8D743154263373E0000D0BCE /* AudioDeviceSelectionDataSource.swift */,
 				98AF5CDE263B4447007608CD /* ParticipantListDataSource.swift */,
 			);
@@ -416,6 +419,7 @@
 				8D743155263373E0000D0BCE /* AudioDeviceSelectionDataSource.swift in Sources */,
 				1F7CD40725C1E9E80081D8F1 /* CallViewController.swift in Sources */,
 				1F7CD40825C1E9E80081D8F1 /* HangupConfirmationViewController.swift in Sources */,
+				98F49DA72654651B00EE4396 /* BottomDrawerDataSource.swift in Sources */,
 				1F5FAD8E25FAC62900E2365F /* CommunicationIdentifierExtension.swift in Sources */,
 				8D743159263373ED000D0BCE /* BottomDrawerCellView.swift in Sources */,
 				1F7CD40625C1E9E80081D8F1 /* FeedbackViewController.swift in Sources */,

--- a/AzureCalling/Controllers/BottomDrawerViewController.swift
+++ b/AzureCalling/Controllers/BottomDrawerViewController.swift
@@ -52,6 +52,15 @@ class BottomDrawerViewController: UIViewController {
         openBottomDrawer()
     }
 
+    func refreshBottomDrawer(dataSource: UITableViewDataSource) {
+        self.tableViewDataSource = dataSource
+        tableView.dataSource = self.tableViewDataSource
+        tableView.reloadData()
+
+        NSLayoutConstraint.deactivate(tableView.constraints)
+        setTableConstraints()
+    }
+
     // MARK: Private Functions
 
     private func createBottomDrawer() {
@@ -66,6 +75,25 @@ class BottomDrawerViewController: UIViewController {
         tableView.delegate = self.tableViewDelegate
         tableView.reloadData()
 
+        setTableConstraints()
+    }
+
+    private func openBottomDrawer() {
+        let showConstraint = NSLayoutConstraint(item: tableView!,
+                attribute: .bottom,
+                relatedBy: .equal,
+                toItem: self.view,
+                attribute: .bottom,
+                multiplier: 1,
+                constant: 0)
+        showConstraint.priority = .required
+        self.view.addConstraint(showConstraint)
+        UIView.animate(withDuration: 0.15, delay: 0, options: .beginFromCurrentState, animations: {
+            self.view.layoutIfNeeded()
+        }, completion: nil)
+    }
+
+    private func setTableConstraints() {
         let window = UIApplication.shared.windows[0]
         let guide = self.view.safeAreaLayoutGuide
         let bottomPadding = window.safeAreaInsets.bottom
@@ -84,20 +112,5 @@ class BottomDrawerViewController: UIViewController {
         tableConstraints.append(hideConstraint)
 
         NSLayoutConstraint.activate(tableConstraints)
-    }
-
-    private func openBottomDrawer() {
-        let showConstraint = NSLayoutConstraint(item: tableView!,
-                attribute: .bottom,
-                relatedBy: .equal,
-                toItem: self.view,
-                attribute: .bottom,
-                multiplier: 1,
-                constant: 0)
-        showConstraint.priority = .required
-        self.view.addConstraint(showConstraint)
-        UIView.animate(withDuration: 0.15, delay: 0, options: .beginFromCurrentState, animations: {
-            self.view.layoutIfNeeded()
-        }, completion: nil)
     }
 }

--- a/AzureCalling/Controllers/BottomDrawerViewController.swift
+++ b/AzureCalling/Controllers/BottomDrawerViewController.swift
@@ -10,17 +10,15 @@ class BottomDrawerViewController: UIViewController {
     // MARK: Properties
 
     private var tableView: UITableView!
-    private var tableViewDataSource: UITableViewDataSource?
-    private weak var tableViewDelegate: UITableViewDelegate?
+    private var bottomDrawerDataSource: BottomDrawerDataSource?
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
 
-    init(dataSource: UITableViewDataSource, delegate: UITableViewDelegate) {
+    init(dataSource: BottomDrawerDataSource) {
         super.init(nibName: nil, bundle: nil)
-        self.tableViewDataSource = dataSource
-        self.tableViewDelegate = delegate
+        self.bottomDrawerDataSource = dataSource
         self.modalPresentationStyle = .overCurrentContext
     }
 
@@ -52,9 +50,8 @@ class BottomDrawerViewController: UIViewController {
         openBottomDrawer()
     }
 
-    func refreshBottomDrawer(dataSource: UITableViewDataSource) {
-        self.tableViewDataSource = dataSource
-        tableView.dataSource = self.tableViewDataSource
+    func refreshBottomDrawer() {
+        bottomDrawerDataSource?.refreshDataSource?()
         tableView.reloadData()
 
         NSLayoutConstraint.deactivate(tableView.constraints)
@@ -71,8 +68,8 @@ class BottomDrawerViewController: UIViewController {
         let cell = UINib(nibName: "BottomDrawerCellView",
                          bundle: nil)
         tableView.register(cell, forCellReuseIdentifier: "BottomDrawerCellView")
-        tableView.dataSource = self.tableViewDataSource
-        tableView.delegate = self.tableViewDelegate
+        tableView.dataSource = self.bottomDrawerDataSource
+        tableView.delegate = self.bottomDrawerDataSource
         tableView.reloadData()
 
         setTableConstraints()

--- a/AzureCalling/Controllers/CallViewController.swift
+++ b/AzureCalling/Controllers/CallViewController.swift
@@ -18,6 +18,8 @@ class CallViewController: UIViewController, UICollectionViewDelegate, UICollecti
     var joinCallConfig: JoinCallConfig!
     var callingContext: CallingContext!
 
+    private var bottomDrawerViewController: BottomDrawerViewController?
+
     private let eventHandlingQueue = DispatchQueue(label: "eventHandlingQueue", qos: .userInteractive)
     private var lastParticipantViewsUpdateTimestamp: TimeInterval = Date().timeIntervalSince1970
     private var isParticipantViewsUpdatePending: Bool = false
@@ -27,23 +29,6 @@ class CallViewController: UIViewController, UICollectionViewDelegate, UICollecti
     private var localParticipantView = ParticipantView()
     private var participantIdIndexPathMap: [String: IndexPath] = [:]
     private var participantIndexPathViewMap: [IndexPath: ParticipantView] = [:]
-
-    private var bottomDrawerViewController: BottomDrawerViewController?
-    private var participantInfoList: [ParticipantInfo] {
-        // Show local participant first
-        var participantInfoList = [
-            ParticipantInfo(
-                displayName: callingContext.displayName + " (Me)",
-                isMuted: callingContext.isCallMuted ?? false)
-        ]
-        // Get the rest of remote participants
-        participantInfoList.append(contentsOf: callingContext.remoteParticipants.map {
-            ParticipantInfo(
-                displayName: $0.displayName,
-                isMuted: $0.isMuted)
-        })
-        return participantInfoList
-    }
 
     // MARK: IBOutlets
 
@@ -163,12 +148,29 @@ class CallViewController: UIViewController, UICollectionViewDelegate, UICollecti
 
     private func openParticipantListDrawer() {
         let participantListDataSource = ParticipantListDataSource()
+        let participantInfoList = getParticipantInfoList()
         participantListDataSource.createParticipantList(participantInfoList)
 
         bottomDrawerViewController = BottomDrawerViewController(
             dataSource: participantListDataSource,
             delegate: participantListDataSource)
         present(bottomDrawerViewController!, animated: false, completion: nil)
+    }
+
+    private func getParticipantInfoList() -> [ParticipantInfo] {
+        // Show local participant first
+        var participantInfoList = [
+            ParticipantInfo(
+                displayName: callingContext.displayName + " (Me)",
+                isMuted: callingContext.isCallMuted ?? false)
+        ]
+        // Get the rest of remote participants
+        participantInfoList.append(contentsOf: callingContext.remoteParticipants.map {
+            ParticipantInfo(
+                displayName: $0.displayName,
+                isMuted: $0.isMuted)
+        })
+        return participantInfoList
     }
 
     // MARK: UICollectionViewDataSource
@@ -592,7 +594,8 @@ class CallViewController: UIViewController, UICollectionViewDelegate, UICollecti
             }
 
             let participantListDataSource = ParticipantListDataSource()
-            participantListDataSource.createParticipantList(self.participantInfoList)
+            let participantInfoList = self.getParticipantInfoList()
+            participantListDataSource.createParticipantList(participantInfoList)
             bottomDrawerViewController.refreshBottomDrawer(dataSource: participantListDataSource)
         }
     }

--- a/AzureCalling/Controllers/CallViewController.swift
+++ b/AzureCalling/Controllers/CallViewController.swift
@@ -147,9 +147,8 @@ class CallViewController: UIViewController, UICollectionViewDelegate, UICollecti
     }
 
     private func openParticipantListDrawer() {
-        let participantListDataSource = ParticipantListDataSource()
-        let participantInfoList = getParticipantInfoList()
-        participantListDataSource.createParticipantList(participantInfoList)
+        let participantListDataSource = ParticipantListDataSource(participantsFetcher: getParticipantInfoList)
+        participantListDataSource.createParticipantList()
 
         bottomDrawerViewController = BottomDrawerViewController(
             dataSource: participantListDataSource,
@@ -593,9 +592,8 @@ class CallViewController: UIViewController, UICollectionViewDelegate, UICollecti
                 return
             }
 
-            let participantListDataSource = ParticipantListDataSource()
-            let participantInfoList = self.getParticipantInfoList()
-            participantListDataSource.createParticipantList(participantInfoList)
+            let participantListDataSource = ParticipantListDataSource(participantsFetcher: self.getParticipantInfoList)
+            participantListDataSource.createParticipantList()
             bottomDrawerViewController.refreshBottomDrawer(dataSource: participantListDataSource)
         }
     }

--- a/AzureCalling/Controllers/CallViewController.swift
+++ b/AzureCalling/Controllers/CallViewController.swift
@@ -138,17 +138,13 @@ class CallViewController: UIViewController, UICollectionViewDelegate, UICollecti
 
     private func openAudioDeviceDrawer() {
         let audioDeviceSelectionDataSource = AudioDeviceSelectionDataSource()
-        let bottomDrawerViewController = BottomDrawerViewController(
-            dataSource: audioDeviceSelectionDataSource,
-            delegate: audioDeviceSelectionDataSource)
+        let bottomDrawerViewController = BottomDrawerViewController(dataSource: audioDeviceSelectionDataSource)
         present(bottomDrawerViewController, animated: false, completion: nil)
     }
 
     private func openParticipantListDrawer() {
         let participantListDataSource = ParticipantListDataSource(participantsFetcher: getParticipantInfoList)
-        bottomDrawerViewController = BottomDrawerViewController(
-            dataSource: participantListDataSource,
-            delegate: participantListDataSource)
+        bottomDrawerViewController = BottomDrawerViewController(dataSource: participantListDataSource)
         present(bottomDrawerViewController!, animated: false, completion: nil)
     }
 
@@ -588,8 +584,7 @@ class CallViewController: UIViewController, UICollectionViewDelegate, UICollecti
                 return
             }
 
-            let participantListDataSource = ParticipantListDataSource(participantsFetcher: self.getParticipantInfoList)
-            bottomDrawerViewController.refreshBottomDrawer(dataSource: participantListDataSource)
+            bottomDrawerViewController.refreshBottomDrawer()
         }
     }
 

--- a/AzureCalling/Controllers/CallViewController.swift
+++ b/AzureCalling/Controllers/CallViewController.swift
@@ -138,8 +138,6 @@ class CallViewController: UIViewController, UICollectionViewDelegate, UICollecti
 
     private func openAudioDeviceDrawer() {
         let audioDeviceSelectionDataSource = AudioDeviceSelectionDataSource()
-        audioDeviceSelectionDataSource.createAudioDeviceOptions()
-
         let bottomDrawerViewController = BottomDrawerViewController(
             dataSource: audioDeviceSelectionDataSource,
             delegate: audioDeviceSelectionDataSource)
@@ -148,8 +146,6 @@ class CallViewController: UIViewController, UICollectionViewDelegate, UICollecti
 
     private func openParticipantListDrawer() {
         let participantListDataSource = ParticipantListDataSource(participantsFetcher: getParticipantInfoList)
-        participantListDataSource.createParticipantList()
-
         bottomDrawerViewController = BottomDrawerViewController(
             dataSource: participantListDataSource,
             delegate: participantListDataSource)
@@ -593,7 +589,6 @@ class CallViewController: UIViewController, UICollectionViewDelegate, UICollecti
             }
 
             let participantListDataSource = ParticipantListDataSource(participantsFetcher: self.getParticipantInfoList)
-            participantListDataSource.createParticipantList()
             bottomDrawerViewController.refreshBottomDrawer(dataSource: participantListDataSource)
         }
     }

--- a/AzureCalling/Controllers/LobbyViewController.swift
+++ b/AzureCalling/Controllers/LobbyViewController.swift
@@ -118,9 +118,7 @@ class LobbyViewController: UIViewController, UITextFieldDelegate {
 
     private func openAudioDeviceDrawer() {
         let audioDeviceSelectionDataSource = AudioDeviceSelectionDataSource()
-        let bottomDrawerViewController = BottomDrawerViewController(
-            dataSource: audioDeviceSelectionDataSource,
-            delegate: audioDeviceSelectionDataSource)
+        let bottomDrawerViewController = BottomDrawerViewController(dataSource: audioDeviceSelectionDataSource)
         present(bottomDrawerViewController, animated: false, completion: nil)
     }
 

--- a/AzureCalling/Controllers/LobbyViewController.swift
+++ b/AzureCalling/Controllers/LobbyViewController.swift
@@ -118,8 +118,6 @@ class LobbyViewController: UIViewController, UITextFieldDelegate {
 
     private func openAudioDeviceDrawer() {
         let audioDeviceSelectionDataSource = AudioDeviceSelectionDataSource()
-        audioDeviceSelectionDataSource.createAudioDeviceOptions()
-
         let bottomDrawerViewController = BottomDrawerViewController(
             dataSource: audioDeviceSelectionDataSource,
             delegate: audioDeviceSelectionDataSource)

--- a/AzureCalling/Controllers/datasource/AudioDeviceSelectionDataSource.swift
+++ b/AzureCalling/Controllers/datasource/AudioDeviceSelectionDataSource.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-class AudioDeviceSelectionDataSource: NSObject, UITableViewDelegate, UITableViewDataSource {
+class AudioDeviceSelectionDataSource: NSObject, BottomDrawerDataSource {
 
     // MARK: Properties
 

--- a/AzureCalling/Controllers/datasource/AudioDeviceSelectionDataSource.swift
+++ b/AzureCalling/Controllers/datasource/AudioDeviceSelectionDataSource.swift
@@ -11,9 +11,16 @@ class AudioDeviceSelectionDataSource: NSObject, UITableViewDelegate, UITableView
 
     private var audioDeviceOptions = [BottomDrawerItem]()
 
-    // MARK: Public API
+    // MARK: Initialization
 
-    func createAudioDeviceOptions() {
+    override init() {
+        super.init()
+        createAudioDeviceOptions()
+    }
+
+    // MARK: Private Functions
+
+    private func createAudioDeviceOptions() {
         let audioDeviceTypes = AudioSessionManager.getAllAudioDeviceTypes()
         let currentAudioDeviceType = AudioSessionManager.getCurrentAudioDeviceType()
 

--- a/AzureCalling/Controllers/datasource/BottomDrawerDataSource.swift
+++ b/AzureCalling/Controllers/datasource/BottomDrawerDataSource.swift
@@ -1,0 +1,10 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+
+@objc protocol BottomDrawerDataSource: UITableViewDelegate, UITableViewDataSource {
+    @objc optional func refreshDataSource()
+}

--- a/AzureCalling/Controllers/datasource/ParticipantListDataSource.swift
+++ b/AzureCalling/Controllers/datasource/ParticipantListDataSource.swift
@@ -19,13 +19,18 @@ class ParticipantListDataSource: NSObject, UITableViewDelegate, UITableViewDataS
     private var participantList = [BottomDrawerItem]()
     private var participantsFetcher: ParticipantsFetcher
 
+    // MARK: Initialization
+
     init(participantsFetcher: @escaping ParticipantsFetcher) {
         self.participantsFetcher = participantsFetcher
+
+        super.init()
+        createParticipantList()
     }
 
-    // MARK: Public API
+    // MARK: Private Functions
 
-    func createParticipantList() {
+    private func createParticipantList() {
         let participantInfoList = self.participantsFetcher()
         let accessoryImage = UIImage(named: "ic_fluent_mic_off_28_filled")!
         let image = UIImage(named: "ic_fluent_person_48_filled")!

--- a/AzureCalling/Controllers/datasource/ParticipantListDataSource.swift
+++ b/AzureCalling/Controllers/datasource/ParticipantListDataSource.swift
@@ -10,15 +10,23 @@ struct ParticipantInfo {
     let isMuted: Bool
 }
 
+typealias ParticipantsFetcher = () -> [ParticipantInfo]
+
 class ParticipantListDataSource: NSObject, UITableViewDelegate, UITableViewDataSource {
 
     // MARK: Properties
 
     private var participantList = [BottomDrawerItem]()
+    private var participantsFetcher: ParticipantsFetcher
+
+    init(participantsFetcher: @escaping ParticipantsFetcher) {
+        self.participantsFetcher = participantsFetcher
+    }
 
     // MARK: Public API
 
-    func createParticipantList(_ participantInfoList: [ParticipantInfo]) {
+    func createParticipantList() {
+        let participantInfoList = self.participantsFetcher()
         let accessoryImage = UIImage(named: "ic_fluent_mic_off_28_filled")!
         let image = UIImage(named: "ic_fluent_person_48_filled")!
 

--- a/AzureCalling/Controllers/datasource/ParticipantListDataSource.swift
+++ b/AzureCalling/Controllers/datasource/ParticipantListDataSource.swift
@@ -12,7 +12,7 @@ struct ParticipantInfo {
 
 typealias ParticipantsFetcher = () -> [ParticipantInfo]
 
-class ParticipantListDataSource: NSObject, UITableViewDelegate, UITableViewDataSource {
+class ParticipantListDataSource: NSObject, BottomDrawerDataSource {
 
     // MARK: Properties
 
@@ -39,6 +39,13 @@ class ParticipantListDataSource: NSObject, UITableViewDelegate, UITableViewDataS
             let participantInfo = BottomDrawerItem(avatar: image, title: participantInfo.displayName, accessoryImage: accessoryImage, enabled: participantInfo.isMuted)
             participantList.append(participantInfo)
         }
+    }
+
+    // MARK: BottomDrawerDataSource events
+
+    func refreshDataSource() {
+        participantList.removeAll()
+        createParticipantList()
     }
 
     // MARK: UITableViewDataSource events


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Allow live update on participant list whenever remote participants join / leave call or mute / unmute

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
* Have remote participants join call, that should increase the participant list while the participant list is in view
* Have remote participants leave call, that should decrease the participant list while the participant list is in view
* Have remote participants mute themselves, that should display the mute indicators beside their names while the participant list is in view
* Have remote participants unmute themselves, that should hide the mute indicators beside their names while the participant list is in view
* Have remote participants that are currently in active display mode to switch on / off their video, that should display their video in the background while the participant list is in view
* Have remote participants that are currently in active display mode to unmute themselves and speak, that should display the active speaker indicators around their portraits in the background while the participant list is in view