### PR TITLE
While updating participant views, defer any further updates until the current update completes

### DIFF
--- a/AzureCalling/Controllers/CallViewController.swift
+++ b/AzureCalling/Controllers/CallViewController.swift
@@ -594,6 +594,23 @@ class CallViewController: UIViewController, UICollectionViewDelegate, UICollecti
         infoHeaderView.updateParticipant(count: callingContext.participantCount)
     }
 
+    private func participantViewUpdate() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+
+            for participant in self.callingContext.displayedRemoteParticipants {
+                if let userIdentifier = participant.identifier.stringValue,
+                   let indexPath = self.participantIdIndexPathMap[userIdentifier],
+                   let participantView = self.participantIndexPathViewMap[indexPath] {
+                    participantView.updateMuteIndicator(isMuted: participant.isMuted)
+                    participantView.updateActiveSpeaker(isSpeaking: participant.isSpeaking)
+                }
+            }
+        }
+    }
+
     private func participantListUpdate() {
         DispatchQueue.main.async { [weak self] in
             guard let self = self,
@@ -613,7 +630,7 @@ class CallViewController: UIViewController, UICollectionViewDelegate, UICollecti
     }
 
     @objc func onRemoteParticipantViewChanged(_ notification: Notification) {
-        queueParticipantViewsUpdate()
+        participantViewUpdate()
         participantListUpdate()
     }
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ~~This pull request creates a separate update function dedicated for both `onIsMutedChanged` and `onIsSpeakingChanged`.~~
* This pull request modifies the participant views update logic so that whenever an update is in progress, we halt any further update requests until the current update completes. Only then we execute another update.
* This addresses the bug reported on https://github.com/Azure/Communication/issues/300 where the `onIsSpeakingChanged` event is being triggered when remote participants leave the call.
* Otherwise, if both `onIsSpeakingChanged` and `onRemoteParticipantsUpdated` events are fired simultaneously, previous implementation uses `queueParticipantViewsUpdate()` for `onIsSpeakingChanged` and `queueParticipantViewsUpdate()` will be invoked twice; the second execution may lead to the evaluation of the expression below, thereby skipping the actual update. This results in the participant views not updating occasionally when remote participants leave the call.
```
if self.isParticipantViewsUpdatePending {
    return
}
```

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
* Make sure remote participants have their mute and active speaker indicators updated correctly when changed
* Make sure participant views updated correctly when remote participants leave the call