### PR TITLE
Utilize mute event from Calling SDK to update indicator

### DIFF
--- a/AzureCalling/Controllers/CallViewController.swift
+++ b/AzureCalling/Controllers/CallViewController.swift
@@ -284,16 +284,7 @@ class CallViewController: UIViewController, UICollectionViewDelegate, UICollecti
 
     @IBAction func onToggleMute(_ sender: UIButton) {
         sender.isSelected.toggle()
-        (sender.isSelected ? callingContext.mute : callingContext.unmute) { [weak self] result in
-            guard let self = self else {
-                return
-            }
-            if case .success = result {
-                DispatchQueue.main.async {
-                    self.localParticipantView.updateMuteIndicator(isMuted: sender.isSelected)
-                }
-            }
-        }
+        (sender.isSelected ? callingContext.mute : callingContext.unmute) { _ in }
     }
 
     @IBAction func selectAudioDeviceButtonPressed(_ sender: UIButton) {
@@ -315,6 +306,7 @@ class CallViewController: UIViewController, UICollectionViewDelegate, UICollecti
     private func onJoinCall() {
         NotificationCenter.default.addObserver(self, selector: #selector(onRemoteParticipantsUpdated(_:)), name: .remoteParticipantsUpdated, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(onRemoteParticipantViewChanged(_:)), name: .remoteParticipantViewChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(onIsMutedChanged(_:)), name: .onIsMutedChanged, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(appResignActive(_:)), name: UIApplication.willResignActiveNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(appAssignActive(_:)), name: UIApplication.didBecomeActiveNotification, object: nil)
 
@@ -623,6 +615,15 @@ class CallViewController: UIViewController, UICollectionViewDelegate, UICollecti
     @objc func onRemoteParticipantViewChanged(_ notification: Notification) {
         queueParticipantViewsUpdate()
         participantListUpdate()
+    }
+
+    @objc func onIsMutedChanged(_ notification: Notification) {
+        if let isCallMuted = callingContext.isCallMuted {
+            toggleMuteButton.isSelected = isCallMuted
+            verticalToggleMuteButton.isSelected = isCallMuted
+            localParticipantView.updateMuteIndicator(isMuted: isCallMuted)
+            participantListUpdate()
+        }
     }
 
     @objc func appResignActive(_ notification: Notification) {

--- a/AzureCalling/External/Calling/CallingContext.swift
+++ b/AzureCalling/External/Calling/CallingContext.swift
@@ -405,6 +405,10 @@ extension CallingContext: CallDelegate {
         notifyRemoteParticipantsUpdated()
     }
 
+    func call(_ call: Call, didChangeMuteState args: PropertyChangedEventArgs) {
+        notifyOnIsMutedChanged()
+    }
+
     private func findInactiveSpeakerToSwap(with remoteParticipant: RemoteParticipant, id: String) {
         for displayedRemoteParticipant in displayedRemoteParticipants {
             if !displayedRemoteParticipant.isSpeaking,
@@ -456,9 +460,14 @@ extension CallingContext: CallDelegate {
     private func notifyRemoteParticipantViewChanged() {
         NotificationCenter.default.post(name: .remoteParticipantViewChanged, object: nil)
     }
+
+    private func notifyOnIsMutedChanged() {
+        NotificationCenter.default.post(name: .onIsMutedChanged, object: nil)
+    }
 }
 
 extension Notification.Name {
     static let remoteParticipantsUpdated = Notification.Name("RemoteParticipantsUpdated")
     static let remoteParticipantViewChanged = Notification.Name("RemoteParticipantViewChanged")
+    static let onIsMutedChanged = Notification.Name("OnIsMutedChanged")
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This Pull Request fixes the bug where the mute status of the local participant does not change when muted by Teams client user
* External controls such as muting from Teams client rely on events to notify us. We utilize the event generated by the Calling SDK to update the mute indicator instead.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
* Ensure standard mute/unmute toggling from local Sample App works as usual
* Bring those changes over to the Teams Interop branch and try muting from Teams call, the following should update as well:
  * State of mute toggle button in vertical mode
  * State of mute toggle button in horizontal mode
  * Mute indicator on the display name
  * Mute indicator in the participant list