### PR TITLE
Move leave call button to be vertically centered

### DIFF
--- a/AzureCalling/Controllers/HangupConfirmationViewController.swift
+++ b/AzureCalling/Controllers/HangupConfirmationViewController.swift
@@ -33,7 +33,7 @@ class HangupConfirmationViewController: UIViewController {
         view.addSubview(cancelButton)
 
         let constraints = [
-            hangupButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -215),
+            hangupButton.bottomAnchor.constraint(equalTo: view.centerYAnchor, constant: -8),
             hangupButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             hangupButton.widthAnchor.constraint(equalToConstant: 328),
             hangupButton.heightAnchor.constraint(equalToConstant: 50),
@@ -42,7 +42,6 @@ class HangupConfirmationViewController: UIViewController {
             cancelButton.heightAnchor.constraint(equalTo: hangupButton.heightAnchor),
             cancelButton.centerXAnchor.constraint(equalTo: hangupButton.centerXAnchor),
             cancelButton.topAnchor.constraint(equalTo: hangupButton.bottomAnchor, constant: 16)
-
         ]
         NSLayoutConstraint.activate(constraints)
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This Pull Request fixes the bug where the leave call buttons not vertically centered on screen

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
* Leave Call button is vertically centered (with a slight offset above center) on the call screen
* Cancel button well spaced below the Leave Call button