### PR TITLE
Fix issue for removed from meeting without alert

### DIFF
--- a/AzureCalling/External/Calling/CallingContext.swift
+++ b/AzureCalling/External/Calling/CallingContext.swift
@@ -12,6 +12,7 @@ enum CallingInterfaceState {
     case waitingAdmission
     case admissionDenied
     case connected
+    case callEnded
     case removed
 }
 
@@ -133,6 +134,7 @@ class CallingContext: NSObject {
     }
 
     func endCall(completionHandler: @escaping (Result<Void, Error>) -> Void) {
+        callingInterfaceState = .callEnded
         self.call?.hangUp(options: HangUpOptions()) { (error) in
             if error != nil {
                 print("ERROR: It was not possible to hangup the call.")
@@ -409,7 +411,7 @@ extension CallingContext: CallDelegate {
         switch call.state {
         case .none:
             if callType == .teamsMeeting {
-                callingInterfaceState = callingInterfaceState == .connected ? .removed : .admissionDenied
+                callingInterfaceState = .admissionDenied
             }
         case .connected:
             callingInterfaceState = .connected
@@ -418,6 +420,10 @@ extension CallingContext: CallDelegate {
             notifyRemoteParticipantsUpdated()
         case .inLobby:
             callingInterfaceState = .waitingAdmission
+        case .disconnected:
+            if callType == .teamsMeeting && callingInterfaceState != .callEnded {
+                callingInterfaceState = .removed
+            }
         default:
             break
         }


### PR DESCRIPTION
## Purpose
* Deal with when end call and when being removed from a call both call state becomes `disconnected` from SDK
* Add a new state to only show alert when local user gets removed from the meeting by Teams client user

## Does this introduce a breaking change?
```
[ ] Yes
[ x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?
```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
* When being removed from a Teams meeting by a client, it should show alert
* When leaving a meeting, it should not show alert
