### PR TITLE
Reset video renderer when backtracking to lobby

### DIFF
--- a/AzureCalling/Controllers/CallViewController.swift
+++ b/AzureCalling/Controllers/CallViewController.swift
@@ -96,6 +96,7 @@ class CallViewController: UIViewController, UICollectionViewDelegate, UICollecti
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+        localParticipantView.dispose()
         self.navigationController?.setNavigationBarHidden(false, animated: animated)
         UIApplication.shared.isIdleTimerDisabled = false
         forcePortraitOrientation()

--- a/AzureCalling/Controllers/LobbyViewController.swift
+++ b/AzureCalling/Controllers/LobbyViewController.swift
@@ -91,9 +91,8 @@ class LobbyViewController: UIViewController, UITextFieldDelegate {
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
     }
 
-    private func setupPreviewView(localVideoStream: LocalVideoStream, retry: Int = 0) {
-        if rendererView == nil,
-           retry <= 3 {
+    private func setupPreviewView(localVideoStream: LocalVideoStream) {
+        if rendererView == nil {
             do {
                 loadingView.startAnimating()
                 previewRenderer = try VideoStreamRenderer(localVideoStream: localVideoStream)
@@ -105,17 +104,8 @@ class LobbyViewController: UIViewController, UITextFieldDelegate {
                 rendererView!.leftAnchor.constraint(equalTo: previewView.leftAnchor).isActive = true
                 rendererView!.rightAnchor.constraint(equalTo: previewView.rightAnchor).isActive = true
                 loadingView.stopAnimating()
-                print("Lobby video view renderer successfully created.")
             } catch {
-                print("Failed to create renderer for lobby video view. " + (retry > 0 ? "Retry attempt #\(retry)" : "Attempt to retry..."))
-
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
-                    guard let self = self else {
-                        return
-                    }
-
-                    self.setupPreviewView(localVideoStream: localVideoStream, retry: retry + 1)
-                }
+                print("Failed to create renderer for lobby video view")
             }
         }
     }
@@ -187,12 +177,12 @@ class LobbyViewController: UIViewController, UITextFieldDelegate {
 
     private func resetRendererView() {
         callingContext.withLocalVideoStream { [weak self] localVideoStream in
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+            DispatchQueue.main.async { [weak self] in
                 guard let self = self else {
                     return
                 }
 
-                self.rendererView = nil
+                self.cleanRenderView()
                 if let localVideoStream = localVideoStream {
                     self.setupPreviewView(localVideoStream: localVideoStream)
                 }
@@ -203,6 +193,8 @@ class LobbyViewController: UIViewController, UITextFieldDelegate {
     private func cleanRenderView() {
         rendererView?.dispose()
         previewRenderer?.dispose()
+        rendererView = nil
+        previewRenderer = nil
     }
 
     private func setupStartCallButton() {

--- a/AzureCalling/Controllers/LobbyViewController.swift
+++ b/AzureCalling/Controllers/LobbyViewController.swift
@@ -75,6 +75,21 @@ class LobbyViewController: UIViewController, UITextFieldDelegate {
         return true
     }
 
+    func resetRendererView() {
+        callingContext.withLocalVideoStream { [weak self] localVideoStream in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                guard let self = self else {
+                    return
+                }
+
+                self.rendererView = nil
+                if let localVideoStream = localVideoStream {
+                    self.setupPreviewView(localVideoStream: localVideoStream)
+                }
+            }
+        }
+    }
+
     // MARK: Private Functions
 
     private func setupUI() {

--- a/AzureCalling/Controllers/LobbyViewController.swift
+++ b/AzureCalling/Controllers/LobbyViewController.swift
@@ -58,6 +58,11 @@ class LobbyViewController: UIViewController, UITextFieldDelegate {
         setupUI()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        resetRendererView()
+    }
+
     deinit {
         cleanRenderView()
     }
@@ -73,21 +78,6 @@ class LobbyViewController: UIViewController, UITextFieldDelegate {
         displayName = (textField.text as NSString?)?.replacingCharacters(in: range, with: string) ?? ""
         updateStartCallButtonState()
         return true
-    }
-
-    func resetRendererView() {
-        callingContext.withLocalVideoStream { [weak self] localVideoStream in
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
-                guard let self = self else {
-                    return
-                }
-
-                self.rendererView = nil
-                if let localVideoStream = localVideoStream {
-                    self.setupPreviewView(localVideoStream: localVideoStream)
-                }
-            }
-        }
     }
 
     // MARK: Private Functions
@@ -192,6 +182,21 @@ class LobbyViewController: UIViewController, UITextFieldDelegate {
         } else {
             // audio not granted only
             updateMicrophoneDisabledPermissionWarning()
+        }
+    }
+
+    private func resetRendererView() {
+        callingContext.withLocalVideoStream { [weak self] localVideoStream in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+                guard let self = self else {
+                    return
+                }
+
+                self.rendererView = nil
+                if let localVideoStream = localVideoStream {
+                    self.setupPreviewView(localVideoStream: localVideoStream)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This PR fixes the bug when a person turns on the video in the lobby screen and tries to join a teams call, but then denied by the host while in the waiting room and revert back to the lobby screen with the video not visible even though it's on.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Steps to Test
1. Join a Teams meeting
2. In the Lobby screen enable camera
3. When Teams client rejects the Admit request, the mobile app will prompt Join request not allowed
4. When go back to the Lobby screen, the camera feed should show video stream, along with Camera icon enabled
5. Make sure turning the video off/on and camera switching works as well before/after joining a call