### PR TITLE
Change way to detect device orientation change

### DIFF
--- a/AzureCalling/Controllers/CallViewController.swift
+++ b/AzureCalling/Controllers/CallViewController.swift
@@ -205,7 +205,7 @@ class CallViewController: UIViewController, UICollectionViewDelegate, UICollecti
             cellWidth = collectionView.bounds.width / 2
             cellHeight = collectionView.bounds.height / 2
         default:
-            if UIDevice.current.orientation.isLandscape {
+            if UIScreen.main.bounds.width > UIScreen.main.bounds.height {
                 cellWidth = collectionView.bounds.width / 3
                 cellHeight = collectionView.bounds.height / 2
             } else {


### PR DESCRIPTION
## Purpose
* Bug fix for 3x2 / 2x3 participant view incorrectly displayed

## Does this introduce a breaking change?
```
[ ] Yes
[ x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?
```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
* When having more than 5 participant in a call, and have the physical device laying flat on a surface still display the participants view correctly

## Other Information
Previous implementation with `UIDevice.current.orientation` was checking for isLandscape, but orientation have other enum such as `.faceUp`, `.faceDown`