### PR TITLE
Dispose participant view after stopping video streaming

### DIFF
--- a/AzureCalling/Controllers/CallViewController.swift
+++ b/AzureCalling/Controllers/CallViewController.swift
@@ -262,13 +262,13 @@ class CallViewController: UIViewController, UICollectionViewDelegate, UICollecti
     @IBAction func onToggleVideo(_ sender: UIButton) {
         sender.isSelected.toggle()
         if sender.isSelected {
-            localParticipantView.dispose()
             callingContext.stopLocalVideoStream { [weak self] _ in
                 guard let self = self else {
                     return
                 }
                 DispatchQueue.main.async {
                     self.localParticipantView.updateVideoDisplayed(isDisplayVideo: false)
+                    self.localParticipantView.dispose()
                     if self.localParticipantIndexPath == nil {
                         self.localVideoViewContainer.isHidden = true
                     }

--- a/AzureCalling/Controllers/CallViewController.swift
+++ b/AzureCalling/Controllers/CallViewController.swift
@@ -262,6 +262,7 @@ class CallViewController: UIViewController, UICollectionViewDelegate, UICollecti
     @IBAction func onToggleVideo(_ sender: UIButton) {
         sender.isSelected.toggle()
         if sender.isSelected {
+            localParticipantView.dispose()
             callingContext.stopLocalVideoStream { [weak self] _ in
                 guard let self = self else {
                     return

--- a/AzureCalling/Controllers/LobbyViewController.swift
+++ b/AzureCalling/Controllers/LobbyViewController.swift
@@ -298,14 +298,13 @@ class LobbyViewController: UIViewController, UITextFieldDelegate {
                     if let localVideoStream = localVideoStream {
                         self.setupPreviewView(localVideoStream: localVideoStream)
                     }
-                    self.rendererView?.isHidden = false
                     self.switchCameraButton.isHidden = false
                     self.updatePermissionView()
                 }
             }
         } else {
-            rendererView?.isHidden = true
             switchCameraButton.isHidden = true
+            self.cleanRenderView()
         }
     }
 

--- a/AzureCalling/External/Calling/CallingContext.swift
+++ b/AzureCalling/External/Calling/CallingContext.swift
@@ -194,16 +194,20 @@ class CallingContext: NSObject {
     func stopLocalVideoStream(completionHandler: @escaping (Result<Void, Error>) -> Void) {
         isCameraPreferredOn = false
         guard let videoStream = self.localVideoStream else {
-            print("Local video has already stopoed")
+            print("Local video has already stopped")
             completionHandler(.success(()))
             return
         }
-        self.call?.stopVideo(stream: videoStream) { (error) in
+        self.call?.stopVideo(stream: videoStream) { [weak self] (error) in
+            guard let self = self else {
+                return
+            }
             if error != nil {
                 print("ERROR: Local video failed to stop. \(error!)")
                 completionHandler(.failure(error!))
                 return
             }
+            self.localVideoStream = nil
             print("Local video stopped successfully")
             completionHandler(.success(()))
         }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This PR fixes the green video indicator being displayed even after turning off the video. By disposing participant view ~before~ after stopping video streaming, the indicator now changes to orange if video is off.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
* During call, dot indicator should be green if video is on
* During call, dot indicator should be orange if video is off