### PR TITLE
Align bottom anchor of the drawer with safe area

### DIFF
--- a/AzureCalling/Controllers/BottomDrawerViewController.swift
+++ b/AzureCalling/Controllers/BottomDrawerViewController.swift
@@ -95,7 +95,7 @@ class BottomDrawerViewController: UIViewController, UIGestureRecognizerDelegate 
         let showConstraint = NSLayoutConstraint(item: tableView!,
                 attribute: .bottom,
                 relatedBy: .equal,
-                toItem: self.view,
+                toItem: self.view.safeAreaLayoutGuide,
                 attribute: .bottom,
                 multiplier: 1,
                 constant: 0)
@@ -109,7 +109,6 @@ class BottomDrawerViewController: UIViewController, UIGestureRecognizerDelegate 
     private func setTableConstraints() {
         let window = UIApplication.shared.windows[0]
         let guide = self.view.safeAreaLayoutGuide
-        let bottomPadding = window.safeAreaInsets.bottom
         let midScreenHeight = window.screen.bounds.height / 2
 
         tableView.isScrollEnabled = tableView.contentSize.height > midScreenHeight
@@ -117,7 +116,7 @@ class BottomDrawerViewController: UIViewController, UIGestureRecognizerDelegate 
         var tableConstraints = [
             tableView.leadingAnchor.constraint(equalTo: guide.leadingAnchor),
             tableView.trailingAnchor.constraint(equalTo: guide.trailingAnchor),
-            tableView.heightAnchor.constraint(equalToConstant: min(tableView.contentSize.height, midScreenHeight) + bottomPadding)
+            tableView.heightAnchor.constraint(equalToConstant: min(tableView.contentSize.height, midScreenHeight))
         ]
 
         let hideConstraint = tableView.topAnchor.constraint(equalTo: self.view.bottomAnchor)


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Align bottom anchor of the drawer with safe area so that the participant names wouldn't be obstructed by the bottom bar of iPhone X and above

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
* participant names wouldn't be obstructed by the bottom bar

## Other Information
<!-- Add any other helpful information that may be needed here. -->
![Simulator Screen Shot - iPhone 11 - 2021-07-22 at 23 24 18](https://user-images.githubusercontent.com/11702891/126816128-c7013566-adb1-40a8-a23e-2702bc12b788.png)
