### PR TITLE
Updated calling sdk to 2.0.1-beta.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ use_frameworks!
 
 target 'AzureCalling' do
 
-pod 'AzureCommunicationCalling', '2.0.0-beta.1'
+pod 'AzureCommunicationCalling', '2.0.1-beta.1'
 pod 'AzureCore', '1.0.0-beta.12'
 pod 'MSAL', '1.1.13'
 pod 'SwiftLint', '0.42.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - AzureCommunicationCalling (2.0.0-beta.1):
-    - AzureCommunicationCommon (~> 1.0)
-  - AzureCommunicationCommon (1.0.1)
+  - AzureCommunicationCalling (2.0.1-beta.1):
+    - AzureCommunicationCommon (~> 1.0.2)
+  - AzureCommunicationCommon (1.0.2)
   - AzureCore (1.0.0-beta.12)
   - MSAL (1.1.13):
     - MSAL/app-lib (= 1.1.13)
@@ -9,7 +9,7 @@ PODS:
   - SwiftLint (0.42.0)
 
 DEPENDENCIES:
-  - AzureCommunicationCalling (= 2.0.0-beta.1)
+  - AzureCommunicationCalling (= 2.0.1-beta.1)
   - AzureCore (= 1.0.0-beta.12)
   - MSAL (= 1.1.13)
   - SwiftLint (= 0.42.0)
@@ -23,12 +23,12 @@ SPEC REPOS:
     - SwiftLint
 
 SPEC CHECKSUMS:
-  AzureCommunicationCalling: 0ebcbd6d230214d5a9f3b6482f3fb42dadf214a7
-  AzureCommunicationCommon: e8bef28d6924b25a32655c2d2089ae8000dcfa57
+  AzureCommunicationCalling: ad5b6c328ecfe4729dcf0b5d99d9415c42c68429
+  AzureCommunicationCommon: 743009b95ca5de0b32fb5327b1105c6239b7d15d
   AzureCore: 2e029168d18ade4f2e8cc59a96f6d8b26acad2b2
   MSAL: 291d1cfc8d095a6bfe669e4beda2c5be6774a4ff
   SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
 
-PODFILE CHECKSUM: c0d6f49f05c6b442d52ebb3b0386e5506c38ab7a
+PODFILE CHECKSUM: 57d3d6a146156d9e97480df024fee9d156d6f886
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.2


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Upgraded the calling sdk for the Teams Interop branch from 2.0.0-beta.1 to 2.0.1-beta.1 
* https://github.com/Azure/Communication/releases/tag/v2.0.1-beta.1  

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ x ] Other... Please describe: SDK upgrade
```

## What to Check
Verify that the following are valid
* Verify that IncomingCall.accept will now throw errors when trying to accept a terminated call or if already in an active call.

## Other Information
<!-- Add any other helpful information that may be needed here. -->
Visit the link to find details of bugs fixed https://github.com/Azure/Communication/releases/tag/v2.0.1-beta.1 
