### PR TITLE
[Bug] Fix issue with video when users re-enter the Lobby view

### DIFF
--- a/AzureCalling/Controllers/IntroViewController.swift
+++ b/AzureCalling/Controllers/IntroViewController.swift
@@ -65,7 +65,7 @@ class IntroViewController: UIViewController {
             fatalError("Unexpected destination: \(destination)")
         }
 
-        joinCallViewController.callingContext = createCallingContextFunction()
+        joinCallViewController.createCallingContextFunction = createCallingContextFunction
     }
 
     // MARK: UI layout

--- a/AzureCalling/Controllers/JoinCallViewController.swift
+++ b/AzureCalling/Controllers/JoinCallViewController.swift
@@ -14,7 +14,7 @@ class JoinCallViewController: UIViewController, UITextFieldDelegate {
 
     // MARK: Properties
 
-    var callingContext: CallingContext!
+    var createCallingContextFunction: (() -> CallingContext)!
 
     private var joinCallType: JoinCallType = .groupCall
 
@@ -101,7 +101,7 @@ class JoinCallViewController: UIViewController, UITextFieldDelegate {
             fatalError("Unexpected destination: \(destination)")
         }
 
-        lobbyViewController.callingContext = callingContext
+        lobbyViewController.callingContext = createCallingContextFunction()
         lobbyViewController.joinInput = joinIdTextField.text!
         lobbyViewController.joinCallType = joinCallType
     }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fix the bug that local video automatically on when users re-enter the Lobby view

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
1. Join the Lobby view with Teams link or Meeting ID
2. Start video
3. Tap back button and navigate to the Join Call View
4. Re-enter the Lobby view
```

## What to Check
Verify that the following are valid
* The video is turned off
* There is no video preview
