### PR TITLE
[Refactor] Update AzureCommuncationCalling library to 2.2.0 release

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ use_frameworks!
 
 target 'AzureCalling' do
 
-pod 'AzureCommunicationCalling', '2.0.0'
+pod 'AzureCommunicationCalling', '2.2.0'
 pod 'AzureCore', '1.0.0-beta.12'
 pod 'MSAL', '1.1.13'
 pod 'SwiftLint', '0.42.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - AzureCommunicationCalling (2.0.0):
+  - AzureCommunicationCalling (2.2.0):
     - AzureCommunicationCommon (~> 1.0.2)
-  - AzureCommunicationCommon (1.0.2)
+  - AzureCommunicationCommon (1.0.3)
   - AzureCore (1.0.0-beta.12)
   - MSAL (1.1.13):
     - MSAL/app-lib (= 1.1.13)
@@ -9,7 +9,7 @@ PODS:
   - SwiftLint (0.42.0)
 
 DEPENDENCIES:
-  - AzureCommunicationCalling (= 2.0.0)
+  - AzureCommunicationCalling (= 2.2.0)
   - AzureCore (= 1.0.0-beta.12)
   - MSAL (= 1.1.13)
   - SwiftLint (= 0.42.0)
@@ -23,12 +23,12 @@ SPEC REPOS:
     - SwiftLint
 
 SPEC CHECKSUMS:
-  AzureCommunicationCalling: 3dd866dceb4318b74383b30b1749700fa069a674
-  AzureCommunicationCommon: 743009b95ca5de0b32fb5327b1105c6239b7d15d
+  AzureCommunicationCalling: 38d174fc96f252aaaff5f758029623656b6c6349
+  AzureCommunicationCommon: 85a3f0ab952db4f88e03bbdb03e79197f90f1d5d
   AzureCore: 2e029168d18ade4f2e8cc59a96f6d8b26acad2b2
   MSAL: 291d1cfc8d095a6bfe669e4beda2c5be6774a4ff
   SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
 
-PODFILE CHECKSUM: 7a48c22ff3afb4ee56fb81d3720a43f1d7b0525f
+PODFILE CHECKSUM: 982153a94491d74f23bf9a75c22d9f104a7cbd8c
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3


### PR DESCRIPTION
## Purpose
Update the AzureCommunicationCalling library dependency to the latest released version

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
No functional changes; just a library version bump.

## What to Check
General functionality of the app

## Other Information
