### PR TITLE
Leah/iPad share sheet support

### DIFF
--- a/AzureCalling/Controllers/InviteViewController.swift
+++ b/AzureCalling/Controllers/InviteViewController.swift
@@ -109,6 +109,15 @@ class InviteViewController: UIViewController {
 
         let activityVC = UIActivityViewController(activityItems: objectsToShare,
                                                   applicationActivities: nil)
+
+        // On iPad the UIActivityViewController will be displayed as a popover.
+        // It requires to set a non-nil sourceView to specify the anchor location for the popover.
+        if let popoverPresentationController = activityVC.popoverPresentationController {
+             popoverPresentationController.sourceView = self.view
+             popoverPresentationController.sourceRect = CGRect(x: self.view.bounds.midX, y: self.view.bounds.midY, width: 0, height: 0)
+            //Remove the arrow
+             popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirection.init(rawValue: 0)
+        }
         self.present(activityVC, animated: true, completion: nil)
     }
 

--- a/AzureCalling/Controllers/InviteViewController.swift
+++ b/AzureCalling/Controllers/InviteViewController.swift
@@ -16,11 +16,18 @@ class InviteViewController: UIViewController {
     private var subtitleLabel: FluentUI.Label!
     private var shareButton: FluentUI.Button!
     private var continueButton: FluentUI.Button!
+    private var shareSheetActivityVC: UIActivityViewController?
 
     // MARK: ViewController Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
+    }
+
+    override func viewDidLayoutSubviews() {
+        if let activityVC = shareSheetActivityVC, let popoverPresentationController = activityVC.popoverPresentationController {
+            setPopoverSourceView(for: popoverPresentationController)
+        }
     }
 
     // MARK: UI layout
@@ -107,18 +114,25 @@ class InviteViewController: UIViewController {
                                               text: groupCallId ?? "",
                                               iconImage: image)]
 
-        let activityVC = UIActivityViewController(activityItems: objectsToShare,
+        shareSheetActivityVC = UIActivityViewController(activityItems: objectsToShare,
                                                   applicationActivities: nil)
 
+        guard let activityVC = shareSheetActivityVC else {
+            return
+        }
         // On iPad the UIActivityViewController will be displayed as a popover.
         // It requires to set a non-nil sourceView to specify the anchor location for the popover.
         if let popoverPresentationController = activityVC.popoverPresentationController {
-             popoverPresentationController.sourceView = self.view
-             popoverPresentationController.sourceRect = CGRect(x: self.view.bounds.midX, y: self.view.bounds.midY, width: 0, height: 0)
+            popoverPresentationController.sourceView = self.view
+            setPopoverSourceView(for: popoverPresentationController)
             //Remove the arrow
-             popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirection.init(rawValue: 0)
+            popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirection.init(rawValue: 0)
         }
         self.present(activityVC, animated: true, completion: nil)
+    }
+
+    private func setPopoverSourceView(for popoverPresentationController: UIPopoverPresentationController) {
+        popoverPresentationController.sourceRect = CGRect(x: self.view.bounds.midX, y: self.view.bounds.midY, width: 0, height: 0)
     }
 
     private func onContinueButtonTapped() {

--- a/AzureCalling/Controllers/InviteViewController.swift
+++ b/AzureCalling/Controllers/InviteViewController.swift
@@ -24,12 +24,6 @@ class InviteViewController: UIViewController {
         setupUI()
     }
 
-    override func viewDidLayoutSubviews() {
-        if let activityVC = shareSheetActivityVC, let popoverPresentationController = activityVC.popoverPresentationController {
-            setPopoverSourceView(for: popoverPresentationController)
-        }
-    }
-
     // MARK: UI layout
     private func setupUI() {
         view.backgroundColor = ThemeColor.lightSurfacesPrimary
@@ -124,15 +118,11 @@ class InviteViewController: UIViewController {
         // It requires to set a non-nil sourceView to specify the anchor location for the popover.
         if let popoverPresentationController = activityVC.popoverPresentationController {
             popoverPresentationController.sourceView = self.view
-            setPopoverSourceView(for: popoverPresentationController)
+            popoverPresentationController.canOverlapSourceViewRect = true
             //Remove the arrow
             popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirection.init(rawValue: 0)
         }
         self.present(activityVC, animated: true, completion: nil)
-    }
-
-    private func setPopoverSourceView(for popoverPresentationController: UIPopoverPresentationController) {
-        popoverPresentationController.sourceRect = CGRect(x: self.view.bounds.midX, y: self.view.bounds.midY, width: 0, height: 0)
     }
 
     private func onContinueButtonTapped() {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* On iPad the UIActivityViewController will be displayed as a popover.
* It requires to set a non-nil sourceView to specify the anchor location for the popover.
* Or else it crashes.
* Got approval from UX for the design.

<img src="https://user-images.githubusercontent.com/107075081/182723489-fa0849c1-e456-4e0e-8816-2a5b66031af8.png" width="200" />

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Get the code and set up with AAD.

## What to Check
Verify that the following are valid
* On iPad and iPhone, users can successfully share group call ID without crashes.

## Other Information
<!-- Add any other helpful information that may be needed here. -->