### PR TITLE
Token fetch Refresher optimization

### DIFF
--- a/AzureCalling/Controllers/InviteViewController.swift
+++ b/AzureCalling/Controllers/InviteViewController.swift
@@ -114,12 +114,11 @@ class InviteViewController: UIViewController {
     }
 
     private func onContinueButtonTapped() {
-        let callConfig = JoinCallConfig(joinId: groupCallId, displayName: displayName ?? "", callType: .groupCall)
-        busyOverlay.presentIn(view: view)
-        self.callingContext.startCallComposite(callConfig, completionHandler: { [weak self] in
-            DispatchQueue.main.async {
-                self?.busyOverlay.hide()
-            }
-        })
+        Task { @MainActor in
+            let callConfig = JoinCallConfig(joinId: groupCallId, displayName: displayName ?? "", callType: .groupCall)
+            busyOverlay.presentIn(view: view)
+            await self.callingContext.startCallComposite(callConfig)
+            self.busyOverlay.hide()
+        }
     }
 }

--- a/AzureCalling/Controllers/InviteViewController.swift
+++ b/AzureCalling/Controllers/InviteViewController.swift
@@ -113,9 +113,8 @@ class InviteViewController: UIViewController {
         self.present(activityVC, animated: true, completion: nil)
     }
 
-    @MainActor
     private func onContinueButtonTapped() {
-        Task {
+        Task { @MainActor in
             let callConfig = JoinCallConfig(joinId: groupCallId, displayName: displayName ?? "", callType: .groupCall)
             busyOverlay.presentIn(view: view)
             await self.callingContext.startCallComposite(callConfig)

--- a/AzureCalling/Controllers/InviteViewController.swift
+++ b/AzureCalling/Controllers/InviteViewController.swift
@@ -113,8 +113,9 @@ class InviteViewController: UIViewController {
         self.present(activityVC, animated: true, completion: nil)
     }
 
+    @MainActor
     private func onContinueButtonTapped() {
-        Task { @MainActor in
+        Task {
             let callConfig = JoinCallConfig(joinId: groupCallId, displayName: displayName ?? "", callType: .groupCall)
             busyOverlay.presentIn(view: view)
             await self.callingContext.startCallComposite(callConfig)

--- a/AzureCalling/Controllers/InviteViewController.swift
+++ b/AzureCalling/Controllers/InviteViewController.swift
@@ -16,6 +16,7 @@ class InviteViewController: UIViewController {
     private var subtitleLabel: FluentUI.Label!
     private var shareButton: FluentUI.Button!
     private var continueButton: FluentUI.Button!
+    private let busyOverlay = BusyOverlay(frame: .zero)
 
     // MARK: ViewController Lifecycle
     override func viewDidLoad() {
@@ -114,6 +115,11 @@ class InviteViewController: UIViewController {
 
     private func onContinueButtonTapped() {
         let callConfig = JoinCallConfig(joinId: groupCallId, displayName: displayName ?? "", callType: .groupCall)
-        callingContext.startCallComposite(callConfig)
+        busyOverlay.presentIn(view: view)
+        self.callingContext.startCallComposite(callConfig, completionHandler: { [weak self] in
+            DispatchQueue.main.async {
+                self?.busyOverlay.hide()
+            }
+        })
     }
 }

--- a/AzureCalling/Controllers/JoinCallViewController.swift
+++ b/AzureCalling/Controllers/JoinCallViewController.swift
@@ -128,6 +128,7 @@ class JoinCallViewController: UIViewController {
         return true
     }
 
+    @MainActor
     private func handleFormState() async {
         guard validateMeetingLink() else {
             joinIdTextField.becomeFirstResponder()
@@ -191,7 +192,7 @@ class JoinCallViewController: UIViewController {
 
     // Action button
     private func handleAction() {
-        Task { @MainActor in
+        Task {
             await handleFormState()
         }
     }

--- a/AzureCalling/Controllers/JoinCallViewController.swift
+++ b/AzureCalling/Controllers/JoinCallViewController.swift
@@ -26,6 +26,7 @@ class JoinCallViewController: UIViewController {
     private var callTypeSelector: FluentUI.SegmentedControl!
     private var actionButton: FluentUI.Button!
     private var contentView: UIView!
+    private let busyOverlay = BusyOverlay(frame: .zero)
 
     // Handle keyboard scrolling the content
     private var bottomConstraint: NSLayoutConstraint!
@@ -166,7 +167,12 @@ class JoinCallViewController: UIViewController {
             return
         }
         let callConfig = JoinCallConfig(joinId: joinId, displayName: displayName ?? "", callType: joinCallType)
-        callingContext.startCallComposite(callConfig)
+        busyOverlay.presentIn(view: view)
+        self.callingContext.startCallComposite(callConfig, completionHandler: { [weak self] in
+            DispatchQueue.main.async {
+                self?.busyOverlay.hide()
+            }
+        })
     }
 
     // MARK: User interaction handling

--- a/AzureCalling/Controllers/JoinCallViewController.swift
+++ b/AzureCalling/Controllers/JoinCallViewController.swift
@@ -128,7 +128,7 @@ class JoinCallViewController: UIViewController {
         return true
     }
 
-    private func handleFormState() {
+    private func handleFormState() async {
         guard validateMeetingLink() else {
             joinIdTextField.becomeFirstResponder()
             typeTitle.colorStyle = .error
@@ -138,7 +138,7 @@ class JoinCallViewController: UIViewController {
 
         if !(displayNameField.text?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? false) {
             // Have a valid display name
-            navigateToCall()
+            await navigateToCall()
         } else {
             let notification = FluentUI.NotificationView()
             notification.setup(style: .dangerToast, message: "Display name is missing")
@@ -162,17 +162,14 @@ class JoinCallViewController: UIViewController {
     }
 
     // MARK: Navigation
-    func navigateToCall() {
+    func navigateToCall() async {
         guard let joinId = joinIdTextField.text?.trimmingCharacters(in: .whitespacesAndNewlines) else {
             return
         }
         let callConfig = JoinCallConfig(joinId: joinId, displayName: displayName ?? "", callType: joinCallType)
         busyOverlay.presentIn(view: view)
-        self.callingContext.startCallComposite(callConfig, completionHandler: { [weak self] in
-            DispatchQueue.main.async {
-                self?.busyOverlay.hide()
-            }
-        })
+        await self.callingContext.startCallComposite(callConfig)
+        self.busyOverlay.hide()
     }
 
     // MARK: User interaction handling
@@ -194,7 +191,9 @@ class JoinCallViewController: UIViewController {
 
     // Action button
     private func handleAction() {
-        handleFormState()
+        Task { @MainActor in
+            await handleFormState()
+        }
     }
 }
 

--- a/AzureCalling/External/Calling/CallingContext.swift
+++ b/AzureCalling/External/Calling/CallingContext.swift
@@ -54,6 +54,7 @@ final class CallingContext {
             }
     }
 
+    @MainActor
     func startCallComposite(_ joinConfig: JoinCallConfig) async {
         let callCompositeOptions = CallCompositeOptions()
         self.callComposite = CallComposite(withOptions: callCompositeOptions)
@@ -64,26 +65,24 @@ final class CallingContext {
 
         do {
             let communicationTokenCredential = try await getTokenCredential()
-            DispatchQueue.main.async {
-                switch joinConfig.callType {
-                case .groupCall:
-                    self.callComposite?.launch(
-                        remoteOptions: RemoteOptions(
-                            for: .groupCall(groupId: uuid),
-                            credential: communicationTokenCredential,
-                            displayName: displayName
-                        )
+            switch joinConfig.callType {
+            case .groupCall:
+                self.callComposite?.launch(
+                    remoteOptions: RemoteOptions(
+                        for: .groupCall(groupId: uuid),
+                        credential: communicationTokenCredential,
+                        displayName: displayName
                     )
+                )
 
-                case .teamsMeeting:
-                    self.callComposite?.launch(
-                        remoteOptions: RemoteOptions(
-                            for: .teamsMeeting(teamsLink: joinIdStr),
-                            credential: communicationTokenCredential,
-                            displayName: displayName
-                        )
+            case .teamsMeeting:
+                self.callComposite?.launch(
+                    remoteOptions: RemoteOptions(
+                        for: .teamsMeeting(teamsLink: joinIdStr),
+                        credential: communicationTokenCredential,
+                        displayName: displayName
                     )
-                }
+                )
             }
         } catch {
             print("ERROR: Cannot start or join a call due to user credential creating error: \(error.localizedDescription).")

--- a/AzureCalling/External/Calling/CallingContext.swift
+++ b/AzureCalling/External/Calling/CallingContext.swift
@@ -28,13 +28,11 @@ final class CallingContext {
     }
 
     // MARK: Private function
-
     private func fetchInitialToken() async -> String? {
         return await withCheckedContinuation { continuation in
             tokenFetcher { token, error in
-                guard error == nil else {
-                    print("ERROR: Failed to fetch initial token. \(error?.localizedDescription ?? "")")
-                    return
+                if let error = error {
+                    print("ERROR: Failed to fetch initial token. \(error.localizedDescription)")
                 }
                 continuation.resume(returning: token)
             }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This refactor is based on the suggestion from the calling SDK team
* for CommunicationTokenRefreshOptions, it's recommended not passing pass initialToken as nil
```
CommunicationTokenRefreshOptions(initialToken: nil, refreshProactively: true, tokenRefresher: tokenRefresher)
```
* The reason being that "the problem is create call agent is blocked unnecessarily if you do it before that you know whether contoso has properly working token refresh url or not instead of trying to debug why createcallagent is stuck"
* Also added activity indicator before launching the call

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[x] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Get the code and set up with AAD.
* Start and Join a group/teams call

## What to Check
*Verify that we can start and join a group/teams call


## Other Information
<!-- Add any other helpful information that may be needed here. -->