### PR TITLE
[Bugfix] Ensure error state is reset and form state is maintained when overridden

### DIFF
--- a/AzureCalling/Controllers/JoinCallViewController.swift
+++ b/AzureCalling/Controllers/JoinCallViewController.swift
@@ -73,10 +73,10 @@ class JoinCallViewController: UIViewController {
         if let teamsUrl = appSettings.teamsUrl,
             isValidTeamsUrl(url: teamsUrl) {
             callTypeSelector.selectedSegmentIndex = JoinCallType.teamsMeeting.rawValue
-            joinIdTextField.text = teamsUrl.absoluteString
+            handleSegmentChanged(action: UIAction(title: teamsUrl.absoluteString, handler: { _ in }) )
         } else if let groupCallUuid = appSettings.groupCallUuid {
             callTypeSelector.selectedSegmentIndex = JoinCallType.groupCall.rawValue
-            joinIdTextField.text = groupCallUuid.uuidString
+            handleSegmentChanged(action: UIAction(title: groupCallUuid.uuidString, handler: { _ in }) )
         }
     }
 
@@ -198,6 +198,8 @@ class JoinCallViewController: UIViewController {
     private func handleSegmentChanged(action: UIAction) {
         if let callType = JoinCallType(rawValue: callTypeSelector.selectedSegmentIndex) {
             joinCallType = callType
+            typeTitle.colorStyle = .secondary
+            joinIdTextField.text = action.title
             switch callType {
             case .groupCall:
                 typeTitle.text = "Group call"


### PR DESCRIPTION
## Purpose
If an override is set from the .xcconfig file, it should keep the state properly in the UI.
This now happens

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Set up the code with a tokenURL
Override the teamsURL in the AppSettings.xcconfig
Go to the join call screen

## What to Check
Verify that the following are valid
* Check that the state of the screen shows the correct UI components.
* Switch to group call, observe the clearing of the text and update of controls
* 
