### PR TITLE
Leah/fix display name missing when not logged in

### DIFF
--- a/AzureCalling/Controllers/IntroViewController.swift
+++ b/AzureCalling/Controllers/IntroViewController.swift
@@ -269,7 +269,8 @@ class IntroViewController: UIViewController {
     private func joinCall() {
         let joinCallVc = JoinCallViewController()
         joinCallVc.callingContext = createCallingContextFunction()
-        joinCallVc.displayName = userDetails?.userProfile?.displayName
+        let appSettings = AppSettings()
+        joinCallVc.displayName = userDetails?.userProfile?.displayName ?? appSettings.displayName
 
         navigationController?.pushViewController(joinCallVc, animated: true)
     }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fix when AAD is not allowed, user's display name from AppSettings.xcconfig is not passed in to the Calling library

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code and setup token url


## What to Check
Verify that the following are valid
* When not logged in through AAD, and when display name is set in AppSettings.xcconfig, verify that display name is properly displayed in the call.

## Other Information
<!-- Add any other helpful information that may be needed here. -->