### PR TITLE
[BugFix] Display name override from AAD, fall back to config file

### DIFF
--- a/AzureCalling/AppSettings.swift
+++ b/AzureCalling/AppSettings.swift
@@ -36,8 +36,8 @@ class AppSettings {
         return settings["aadScopes"] as! [String]
     }
 
-    var displayName: String {
-        return settings["displayName"] as? String ?? ""
+    var displayName: String? {
+        return settings["displayName"] as? String
     }
 
     var teamsUrl: URL? {

--- a/AzureCalling/Controllers/IntroViewController.swift
+++ b/AzureCalling/Controllers/IntroViewController.swift
@@ -286,15 +286,18 @@ class IntroViewController: UIViewController {
     private func joinCall() {
         let joinCallVc = JoinCallViewController()
         joinCallVc.callingContext = createCallingContextFunction()
-        let appSettings = AppSettings()
-        joinCallVc.displayName = userDetails?.userProfile?.displayName ?? appSettings.displayName
-
+        joinCallVc.displayName = displayName()
         navigationController?.pushViewController(joinCallVc, animated: true)
     }
 
     private func startCall() {
         let startCallVc = StartCallViewController()
         startCallVc.callingContext = createCallingContextFunction()
+        startCallVc.displayName = displayName()
         navigationController?.pushViewController(startCallVc, animated: true)
+    }
+
+    private func displayName() -> String? {
+        return userDetails?.userProfile?.displayName ?? AppSettings().displayName
     }
 }

--- a/AzureCalling/Controllers/JoinCallViewController.swift
+++ b/AzureCalling/Controllers/JoinCallViewController.swift
@@ -64,12 +64,12 @@ class JoinCallViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
+        if displayNameField.text?.isEmpty ?? true {
+            displayNameField.text = displayName ?? ""
+        }
+
         // Set up any developer overrides from the AppConfig.xcconfig file
         let appSettings = AppSettings()
-        if displayNameField.text?.isEmpty ?? true,
-            !appSettings.displayName.isEmpty {
-            displayNameField.text = appSettings.displayName
-        }
         if let teamsUrl = appSettings.teamsUrl,
             isValidTeamsUrl(url: teamsUrl) {
             callTypeSelector.selectedSegmentIndex = JoinCallType.teamsMeeting.rawValue

--- a/AzureCalling/Controllers/StartCallViewController.swift
+++ b/AzureCalling/Controllers/StartCallViewController.swift
@@ -13,6 +13,7 @@ class StartCallViewController: UIViewController {
 
     // MARK: Properties
     var callingContext: CallingContext!
+    var displayName: String?
 
     private var contentView: UIView!
     private var displayNameStackView: UIStackView!
@@ -52,12 +53,15 @@ class StartCallViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        // Set up any developer overrides from the AppConfig.xcconfig file
-        let appSettings = AppSettings()
-        if displayNameTextField.text?.isEmpty ?? true,
-            !appSettings.displayName.isEmpty {
-            displayNameTextField.text = appSettings.displayName
-        } else {
+        if displayNameTextField.text?.isEmpty ?? true {
+            displayNameTextField.text = displayName ?? ""
+        }
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        if displayNameTextField.text?.isEmpty ?? true {
             displayNameTextField.becomeFirstResponder()
         }
     }


### PR DESCRIPTION
## Purpose
Starting a call when using AAD now pre-populates the display name field if available in the start call screen

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Get the code
* Configure for AAD

## What to Check
Verify that the following are valid
* Verify that the start call screen has the display name populated from the AAD
* Verify that the AAD display name overrides the config file one if set.
